### PR TITLE
ci: macos apple silicon tests

### DIFF
--- a/.github/workflows/Nix.yml
+++ b/.github/workflows/Nix.yml
@@ -34,8 +34,8 @@ jobs:
         run: nix build --dry-run -L '.#nixosConfigurations.framework.config.system.build.toplevel' --show-trace
 
   # FIXME: waiting for github to release Apple Silicon CI runners
-  macos-test:
-    name: "macOS Nix Test"
+  macos-x86-test:
+    name: "macOS Intel Nix Test"
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,3 +49,17 @@ jobs:
       - name: "Build NixOS config ❄️"
         run: nix run nix-darwin -- check --flake .#macbook_x86
 
+  macos-arm-test:
+    name: "macOS Apple Silicon Nix Test"
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Install Nix ❄️"
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: "Nix Cache"
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: "Build NixOS config ❄️"
+        run: nix run nix-darwin -- check --flake .#macbook


### PR DESCRIPTION
This pull request adds macOS Apple Silicon tests to the CI workflow. It includes a new job called "macos-arm-test" that runs on macOS 14 and performs the necessary steps to test the code on Apple Silicon. This ensures that the code is compatible with both Intel and Apple Silicon architectures.

Closes #6.