### PR TITLE
feat(helix): ChatGPT/Copilot integration with `helix-gpt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ These are my NixOS/macOS Nix setup.
   - [`taplo`](https://taplo.tamasfe.dev/): TOML
   - [`yaml-language-server`](https://github.com/redhat-developer/yaml-language-server): YAML
   - [`pyright`](https://github.com/microsoft/pyright): Python
+  - [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp): Python
   - [`marksman`](https://github.com/artempyanykh/marksman): Markdown
   - [`vscode-langservers-extracted`](https://github.com/hrsh7th/vscode-langservers-extracted): HTML, CSS, and JSON
   - [`typst-lsp`](https://github.com/nvarner/typst-lsp): [Typst](https://typst.app)
+  - [`helix-gpt`](https://github.com/leona/helix-gpt): ChatGPT/Copilot/LLM support
+    (don't forget to check how to setup your environment variables,
+    I am using [`ryantm/agenix`](https://github.com/ryantm/agenix))
 
 - [Catppuccin](https://catppuccin.com) Mocha theme everywhere.
 - Archival tools:

--- a/common/age.nix
+++ b/common/age.nix
@@ -8,6 +8,7 @@
       luks.file = ../secrets/luks.age;
       password.file = ../secrets/password.age;
       root.file = ../secrets/root.age;
+      copilot.file = ../secrets/copilot.age;
     };
     identityPaths = [
       ../secrets/identities/age-yubikey-identity-95a7c5c3-usb_c.txt

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1703433843,
-        "narHash": "sha256-nmtA4KqFboWxxoOAA6Y1okHbZh+HsXaMPFkYHsoDRDw=",
+        "lastModified": 1707830867,
+        "narHash": "sha256-PAdwm5QqdlwIqGrfzzvzZubM+FXtilekQ/FA0cI49/o=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "417caa847f9383e111d1397039c9d4337d024bf0",
+        "rev": "8cb01a0e717311680e0cbca06a76cbceba6f3ed6",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         "pre-commit": "pre-commit"
       },
       "locked": {
-        "lastModified": 1701036929,
-        "narHash": "sha256-5TkAr5a3EoY9/oeO53SU+FRNfOUTpChj7mEW/Ax3T1w=",
+        "lastModified": 1708283120,
+        "narHash": "sha256-IgJe5xhssW199zGQq4Q81stGdVDJH7nFHm3yu62I75E=",
         "owner": "dwarfmaster",
         "repo": "arkenfox-nixos",
-        "rev": "1c9d061a4ef7bf3ce8a5260eaee4acdb3ee097f9",
+        "rev": "05e7e0996493f47bbc15228895c4e31ce24616f0",
         "type": "github"
       },
       "original": {
@@ -106,11 +106,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706491084,
-        "narHash": "sha256-eaEv+orTmr2arXpoE4aFZQMVPOYXCBEbLgK22kOtkhs=",
+        "lastModified": 1708305517,
+        "narHash": "sha256-WYnEspeTTksC21obnnxWOGOAQbnBD0GES0S0XOLsJjs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "f67ba6552845ea5d7f596a24d57c33a8a9dc8de9",
+        "rev": "1ae1f57dad13595600dd57b6a55fcbaef6673804",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -170,11 +170,11 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -188,11 +188,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1706569497,
-        "narHash": "sha256-oixb0IDb5eZYw6BaVr/R/1pSoMh4rfJHkVnlgeRIeZs=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "60c614008eed1d0383d21daac177a3e036192ed8",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -231,11 +231,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704152458,
-        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "88a2cd8166694ba0b6cb374700799cec53aef527",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
         "type": "github"
       },
       "original": {
@@ -264,11 +264,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -282,11 +282,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -318,11 +318,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
@@ -358,11 +358,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1703887061,
+        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
         "type": "github"
       },
       "original": {
@@ -444,11 +444,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706473109,
-        "narHash": "sha256-iyuAvpKTsq2u23Cr07RcV5XlfKExrG8gRpF75hf1uVc=",
+        "lastModified": 1708294481,
+        "narHash": "sha256-DZtxmeb4OR7iCaKUUuq05ADV2rX8WReZEF7Tq//W0+Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d634c3abafa454551f2083b054cd95c3f287be61",
+        "rev": "a54e05bc12d88ff2df941d0dc1183cb5235fa438",
         "type": "github"
       },
       "original": {
@@ -466,11 +466,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704498488,
-        "narHash": "sha256-yINKdShHrtjdiJhov+q0s3Y3B830ujRoSbHduUNyKag=",
+        "lastModified": 1706306660,
+        "narHash": "sha256-lZvgkHtVeduGByPb0Tz9LpAi4olfkEm8XPgv0o7GRsk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "51e44a13acea71b36245e8bd8c7db53e0a3e61ee",
+        "rev": "b2f56952074cb46e93902ecaabfb04dd93733434",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1705593452,
-        "narHash": "sha256-ZmkRJVLHV+oeD7Px28yW13dnbnuPekEslwfrcw8ErbU=",
+        "lastModified": 1707145991,
+        "narHash": "sha256-N/coQEq6/KXMGuQfL1ZE2bUbVI8el8gsmJtghOTdiiM=",
         "owner": "storopoli",
         "repo": "neovix",
-        "rev": "2590b47b61cc2ada3116db4f98fce89300cbdffc",
+        "rev": "b995708614a93e357bb9e1e7a4876050d465e7c9",
         "type": "github"
       },
       "original": {
@@ -554,11 +554,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704277720,
-        "narHash": "sha256-meAKNgmh3goankLGWqqpw73pm9IvXjEENJloF0coskE=",
+        "lastModified": 1705915768,
+        "narHash": "sha256-+Jlz8OAqkOwJlioac9wtpsCnjgGYUhvLpgJR/5tP9po=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "0dd382b70c351f528561f71a0a7df82c9d2be9a4",
+        "rev": "1e706ef323de76236eb183d7784f3bd57255ec0b",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706581965,
-        "narHash": "sha256-1H7dRdK9LJ7+2X1XQtbwXr+QMqtVVo/ZF0/LIvkjdK8=",
+        "lastModified": 1708231718,
+        "narHash": "sha256-IZdieFWvhBkxoOFMDejqLUYqD94WN6k0YSpw0DFy+4g=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "91b9daf672c957ef95a05491a75f62e6a01d5aaf",
+        "rev": "0e6857fa1d632637488666c08e7b02c08e3178f8",
         "type": "github"
       },
       "original": {
@@ -640,11 +640,11 @@
     },
     "nixos-flake": {
       "locked": {
-        "lastModified": 1705990839,
-        "narHash": "sha256-Gb0bvp7BiHBn2PkssT4CiBhD7lVWqSHEBfiai/RFfSQ=",
+        "lastModified": 1707501063,
+        "narHash": "sha256-7CINolspTZ/pcj2o/Um7A1wrpa7Irt6Nhxwqw4gOHWE=",
         "owner": "srid",
         "repo": "nixos-flake",
-        "rev": "244072b1f9088833627046d703d7973b90fe7843",
+        "rev": "3891b2030114f8661402991eac9be0ed59f786ae",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1706182238,
-        "narHash": "sha256-Ti7CerGydU7xyrP/ow85lHsOpf+XMx98kQnPoQCSi1g=",
+        "lastModified": 1708091350,
+        "narHash": "sha256-o28BJYi68qqvHipT7V2jkWxDiMS1LF9nxUsou+eFUPQ=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f84eaffc35d1a655e84749228cde19922fcf55f1",
+        "rev": "106d3fec43bcea19cb2e061ca02531d54b542ce3",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1703961334,
-        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
         "type": "github"
       },
       "original": {
@@ -721,16 +721,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1685801374,
-        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -753,11 +753,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1689261696,
-        "narHash": "sha256-LzfUtFs9MQRvIoQ3MfgSuipBVMXslMPH/vZ+nM40LkA=",
+        "lastModified": 1704842529,
+        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "df1eee2aa65052a18121ed4971081576b25d6b5c",
+        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
         "type": "github"
       },
       "original": {
@@ -769,11 +769,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1704538339,
-        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
+        "lastModified": 1706191920,
+        "narHash": "sha256-eLihrZAPZX0R6RyM5fYAWeKVNuQPYjAkCUBr+JNvtdE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
+        "rev": "ae5c332cbb5827f6b1f02572496b141021de335f",
         "type": "github"
       },
       "original": {
@@ -785,11 +785,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1708118438,
+        "narHash": "sha256-kk9/0nuVgA220FcqH/D2xaN6uGyHp/zoxPNUmPCMmEE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "5863c27340ba4de8f83e7e3c023b9599c3cb3c80",
         "type": "github"
       },
       "original": {
@@ -840,11 +840,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1705099172,
-        "narHash": "sha256-1ZwpL1E53AJscPHbY6Vu34OJlJYey0NliJlC/d/bbso=",
+        "lastModified": 1706539542,
+        "narHash": "sha256-Zbd9/0iTDNwf6ePvKkISvSMK6S7kmfsPzyG5f57sVA8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "749a8a38c4745ba2540c70f0b15f1c4af10da180",
+        "rev": "37d124e94603f821b56072794c4800ad10252fd7",
         "type": "github"
       },
       "original": {
@@ -903,11 +903,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706741181,
-        "narHash": "sha256-3HtpuacqZ8dEFYGWBFWt8LEGMwl9t9uyOUp3OuThGPM=",
+        "lastModified": 1708329376,
+        "narHash": "sha256-E5LJjNT6dMD2r6m93CdOccQmW3+YT7Pr2lHMMmr5pXs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "006d88080f6b231ea268bb3298f23040eaa8cd1e",
+        "rev": "e17ac139d5903c021aff79b52d659bf90145cbb2",
         "type": "github"
       },
       "original": {
@@ -925,11 +925,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700922917,
-        "narHash": "sha256-ej2fch/T584b5K9sk1UhmZF7W6wEfDHuoUYpFN8dtvM=",
+        "lastModified": 1708018599,
+        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e5ee5c5f3844550c01d2131096c7271cec5e9b78",
+        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
         "type": "github"
       },
       "original": {
@@ -955,11 +955,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704668415,
-        "narHash": "sha256-BMzNHFod53iiU4lkR5WHwqQCFmaCLq85sUCskXneXlA=",
+        "lastModified": 1705757126,
+        "narHash": "sha256-Eksr+n4Q8EYZKAN0Scef5JK4H6FcHc+TKNHb95CWm+c=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "44493e2b3c3ebcd39a9947e9ed9f2c2af164ec4c",
+        "rev": "f56597d53fd174f796b5a7d3ee0b494f9e2285cc",
         "type": "github"
       },
       "original": {
@@ -1051,11 +1051,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1706667075,
-        "narHash": "sha256-KBI5jcOWh9nsOFWj2SRq7vj+fPDf8Do8ceL582kFA70=",
+        "lastModified": 1708308739,
+        "narHash": "sha256-FtKWP6d51kz8282jfziNNcCBpAvEzv2TtKH6dYIXCuA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2c993daf3136c6955fd13bfe215d0d4faf6090f1",
+        "rev": "d45281ce1027a401255db01ea44972afbc569b7e",
         "type": "github"
       },
       "original": {
@@ -1159,11 +1159,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1706462057,
-        "narHash": "sha256-7dG1D4iqqt0bEbBqUWk6lZiSqqwwAO0Hd1L5opVyhNM=",
+        "lastModified": 1707300477,
+        "narHash": "sha256-qQF0fEkHlnxHcrKIMRzOETnRBksUK048MXkX0SOmxvA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c6153c2a3ff4c38d231e3ae99af29b87f1df5901",
+        "rev": "ac599dab59a66304eb511af07b3883114f061b9d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -164,7 +164,11 @@
                 self.darwinModules_.home-manager
                 {
                   home-manager.users.user = {
-                    imports = [ self.homeModules.common self.homeModules.darwin ];
+                    imports = [
+                      self.homeModules.common
+                      self.homeModules.darwin
+                      inputs.agenix.homeManagerModules.age
+                    ];
                     home.stateVersion = homeStateVersion;
                   };
                 }

--- a/flake.nix
+++ b/flake.nix
@@ -121,10 +121,12 @@
                       imports = [
                         self.homeModules.common
                         self.homeModules.linux
+                        inputs.agenix.homeManagerModules.age
                         inputs.nur.hmModules.nur
                         inputs.arkenfox.hmModules.default
                       ];
                       home.stateVersion = "${stateVersion}";
+                      systemd.user.startServices = "sd-switch";
                     };
                   };
                 }
@@ -143,7 +145,11 @@
                 self.darwinModules_.home-manager
                 {
                   home-manager.users.user = {
-                    imports = [ self.homeModules.common self.homeModules.darwin ];
+                    imports = [
+                      self.homeModules.common
+                      self.homeModules.darwin
+                      inputs.agenix.homeManagerModules.age
+                    ];
                     home.stateVersion = homeStateVersion;
                   };
                 }

--- a/home-manager/age.nix
+++ b/home-manager/age.nix
@@ -1,0 +1,6 @@
+{ config, pkgs, lib, ... }:
+
+{
+  age.secrets.copilot.file = ../secrets/copilot.age;
+}
+

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -6,5 +6,6 @@
     ./cli
     ./shell
     ./helix.nix
+    ./age.nix
   ];
 }

--- a/home-manager/helix.nix
+++ b/home-manager/helix.nix
@@ -1,5 +1,14 @@
 { config, pkgs, lib, ... }:
 
+let
+  helix-gpt-wrapper = pkgs.writeScriptBin "helix-gpt" ''
+    #!/usr/bin/env bash
+    set -e
+
+    ${pkgs.helix-gpt}/bin/helix-gpt $@
+  '';
+in
+
 {
   programs = {
     helix = {
@@ -18,6 +27,8 @@
         taplo
         typst-lsp
         yaml-language-server
+        helix-gpt
+        helix-gpt-wrapper
 
         # debugger
         lldb # provides lldb-vscode
@@ -114,6 +125,13 @@
 
           "typst-lsp" = {
             command = "typst-lsp";
+
+          "gpt" = {
+            command = "helix-gpt";
+            args = [
+              "--handler"
+              "copilot"
+            ];
           };
 
         };
@@ -121,7 +139,7 @@
         language = [
           {
             name = "rust";
-            language-servers = [ "rust-analyzer" ];
+            language-servers = [ "rust-analyzer" "gpt" ];
           }
           {
             name = "python";
@@ -134,7 +152,7 @@
           }
           {
             name = "toml";
-            language-servers = [ "taplo" ];
+            language-servers = [ "taplo" "gpt" ];
             formatter = {
               command = "taplo";
               args = [ "fmt" "-" ];
@@ -143,11 +161,11 @@
           }
           {
             name = "yaml";
-            language-servers = [ "yaml-language-server" ];
+            language-servers = [ "yaml-language-server" "gpt" ];
           }
           {
             name = "nix";
-            language-servers = [ "nil" ];
+            language-servers = [ "nil" "gpt" ];
             formatter = {
               command = "nixpkgs-fmt";
             };
@@ -162,7 +180,7 @@
           }
           {
             name = "markdown";
-            language-servers = [ "marksman" ];
+            language-servers = [ "marksman" "gpt" ];
             formatter = {
               command = "dprint";
               args = [ "fmt" "--stdin" "md" ];
@@ -173,7 +191,7 @@
             # FIXME: in the next helix release typst will be included
             name = "typst";
             scope = "source.typst";
-            language-servers = [ "typst-lsp" ];
+            language-servers = [ "typst-lsp" "gpt" ];
             injection-regex = "typst";
             file-types = [ "typ" "typst" ];
             comment-token = "//";
@@ -210,5 +228,10 @@
 
       };
     };
+  };
+  home.sessionVariables = {
+    COPILOT_API_KEY = ''
+      $(${pkgs.coreutils}/bin/cat ${config.age.secrets.copilot.path})
+    '';
   };
 }

--- a/home-manager/helix.nix
+++ b/home-manager/helix.nix
@@ -23,6 +23,7 @@ in
         nodePackages_latest.bash-language-server
         nodePackages_latest.vscode-langservers-extracted
         nodePackages_latest.pyright
+        ruff-lsp
         rust-analyzer
         taplo
         typst-lsp
@@ -110,6 +111,13 @@ in
       languages = {
         language-server = {
 
+          "rust-analyzer".config = {
+            check.command = "clippy";
+            cargo.features = "all";
+          };
+
+          "ruff-lsp".command = "ruff-lsp";
+
           "yaml-language-server".config = {
             yaml = {
               format = { enable = true; };
@@ -123,8 +131,7 @@ in
             };
           };
 
-          "typst-lsp" = {
-            command = "typst-lsp";
+          "typst-lsp".command = "typst-lsp";
 
           "gpt" = {
             command = "helix-gpt";
@@ -143,7 +150,7 @@ in
           }
           {
             name = "python";
-            language-servers = [ "pyright" ];
+            language-servers = [ "pyright" "ruff-lsp" "gpt" ];
             formatter = {
               command = "black";
               args = [ "--quiet" "-" ];

--- a/secrets.nix
+++ b/secrets.nix
@@ -9,4 +9,5 @@ in
   "secrets/luks.age".publicKeys = keys;
   "secrets/password.age".publicKeys = keys;
   "secrets/root.age".publicKeys = keys;
+  "secrets/copilot.age".publicKeys = keys;
 }

--- a/secrets/copilot.age
+++ b/secrets/copilot.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> piv-p256 lafFww A9ftmHDHC6SHbfBOzebW5FCGSAQZBfc0n87RbcVjynbW
+HCMdNcFrMfCMFnOK8kujYIUyyQLtrrzXHSwSri7Z8+w
+-> piv-p256 IyYUHQ A584AUjzYFwJ0bz0xPJJz8MOG3H9hvo8ykvI4APNy5CE
+PcgYzI6R9yJ1QyfMRgdHp855vAzTMQVB+Pl6c/Ubupo
+--- xHnBRaoK/YdkM6RypaEtB7AYA72OHfqu5+e8vAip+zo
+J¨±Ã“×g†^ÊoÅ¶:ù¬YÔ!JYCú2ÕpÅ‘°¸¸(å¿¢l€·–P#™ü(§¨gVòˆ¹úµ&Ì[ãÝ¾·[å?dÚ[¼æ


### PR DESCRIPTION
- Uses [`helix-gpt`](https://github.com/leona/helix-gpt)
- Store the GitHub Copilot API token in an [`agenix`](https://github.com/ryantm/agenix)
  secret with `home-manager`.
- Adds `rust-analyzer` configs
- Adds `ruff-lsp` for python