### PR TITLE
feat(linux): rust mold linker

### DIFF
--- a/common/packages.nix
+++ b/common/packages.nix
@@ -40,7 +40,6 @@ in
     p7zip
 
     # programming
-    mold
     rust
     julia-bin
     python3

--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -9,6 +9,7 @@
     ./mpv
     ./rnnoise.nix
     ./zathura.nix
+    ./mold.nix
   ];
   home = {
     username = "user";

--- a/home-manager/linux/mold.nix
+++ b/home-manager/linux/mold.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+{
+  home.file = {
+    ".cargo/config.toml".text = ''
+      [target.x86_64-unknown-linux-gnu]
+      linker = "clang"
+      rustflags = ["-C", "link-arg=-fuse-ld=${pkgs.mold}/bin/mold"]
+    '';
+  };
+}


### PR DESCRIPTION
Adds a `.cargo/cargo.toml` with `mold` as a linker.

`mold` is up to 5x faster than LLD.